### PR TITLE
InvalidKeyException thrown in login() method if no session is returned

### DIFF
--- a/src/Exception/InvalidKeyException.php
+++ b/src/Exception/InvalidKeyException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WyszukiwarkaRegon\Exception;
+
+class InvalidKeyException extends RegonException
+{
+    /**
+     * @param string $message Exception message
+     * @param int $code
+     */
+    public function __construct(
+        $message,
+        $code
+    ) {
+        parent::__construct($message, $code);
+    }
+}

--- a/src/Service.php
+++ b/src/Service.php
@@ -3,6 +3,7 @@
 namespace WyszukiwarkaRegon;
 
 use WyszukiwarkaRegon\Enum\GetValue;
+use WyszukiwarkaRegon\Exception\InvalidKeyException;
 use WyszukiwarkaRegon\Exception\RegonException;
 use WyszukiwarkaRegon\Exception\SearchException;
 
@@ -124,6 +125,11 @@ class Service
             $response = $this->transport->__soapCall('Zaloguj', [$params]);
         } catch (\SoapFault $e) {
             throw new RegonException($e->getMessage(), 0, $e);
+        }
+
+        if (empty($response->ZalogujResult)) {
+            //Invalid key
+            throw new InvalidKeyException('Invalid api key', 99);
         }
 
         $this->setSession($response->ZalogujResult);

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -39,4 +39,15 @@ class LoginTest extends AbstractTest
         $client = $this->createFault($sopaFault);
         $client->logout();
     }
+
+    /**
+     * @expectedException \WyszukiwarkaRegon\Exception\InvalidKeyException
+     */
+    public function testLoginInvalidKeyException()
+    {
+        $result = new \stdClass();
+        $result->ZalogujResult = '';
+        $client = $this->createClient($result);
+        $client->login();
+    }
 }


### PR DESCRIPTION
throw InvalidKeyException if no session is returned from SOAP login method. This means that the api key provided is invalid
