### PR TITLE
Library uses wyszukiwarkaregontest.stat.gov.pl on PHP7

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -38,6 +38,7 @@ class Transport extends \SoapClient
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
+        $location = $this->location;
         $response = parent::__doRequest($request, $location, $action, $version);
         if (!$response) {
             return $response;


### PR DESCRIPTION
on PHP7 `location` is ignored and default `WSDL` location is used

fix #7 
