### PR TITLE
Fix: Show more than one PKD

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -279,10 +279,15 @@ class Service
     private function xml2array($xml)
     {
         $arr = array();
+        $counter = 1;
         foreach ($xml as $element) {
             /** @var \SimpleXmlElement $element */
             $tag = $element->getName();
             $e = get_object_vars($element);
+            if (array_key_exists($tag, $arr)) {
+                $counter++;
+                $tag .= "_" . $counter;
+            }            
             $arr[$tag] = trim($element);
             if (!empty($e)) {
                 $arr[$tag] = $element instanceof \SimpleXMLElement ? $this->xml2array($element) : $e;

--- a/src/Service.php
+++ b/src/Service.php
@@ -287,7 +287,7 @@ class Service
             if (array_key_exists($tag, $arr)) {
                 $counter++;
                 $tag .= "_" . $counter;
-            }            
+            }
             $arr[$tag] = trim($element);
             if (!empty($e)) {
                 $arr[$tag] = $element instanceof \SimpleXMLElement ? $this->xml2array($element) : $e;


### PR DESCRIPTION
For now API return only one PKD number for a company. PKD data are written under "dane" key, so if there is more than one PKD, It will overwrite the previous one.  Fix adds suffix to "dane" key, ie "dane", "dane_2", "dane_3" and so on for every next number. Solution shouldn't break/change usage of API.
